### PR TITLE
Add geometry_msgs dependency to ihmc_msgs and tweak the installation …

### DIFF
--- a/ihmc_msgs/package.xml
+++ b/ihmc_msgs/package.xml
@@ -12,10 +12,12 @@
 
   <author email="dstephen@ihmc.us">Doug Stephen</author>
 
-  <build_depend>message_generation</build_depend>
-  <run_depend>message_runtime</run_depend>
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>message_generation</build_depend>
   <build_depend>std_msgs</build_depend>
+  <run_depend>geometry_msgs</run_depend>
+  <run_depend>message_runtime</run_depend>
   <run_depend>std_msgs</run_depend>
 
 </package>

--- a/ihmc_ros_java_adapter/CMakeLists.txt
+++ b/ihmc_ros_java_adapter/CMakeLists.txt
@@ -1,10 +1,8 @@
+
 cmake_minimum_required(VERSION 2.8.3)
 project(ihmc_ros_java_adapter)
-
 find_package(catkin REQUIRED COMPONENTS
-
 )
-
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES ihmc_msgs
@@ -12,12 +10,21 @@ catkin_package(
 #  DEPENDS system_lib
 )
 
-install(DIRECTORY .
+install(FILES
+  build.gradle
+  settings.gradle
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-  PATTERN "*.gradle"
-  PATTERN "gradle/*"
-  PATTERN "buildSrc/*"
-  PATTERN "gradlew"
-  PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
-                    GROUP_EXECUTE GROUP_READ
+)
+
+install(PROGRAMS
+ gradlew
+ DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+install(DIRECTORY gradle
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+install(DIRECTORY buildSrc
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )


### PR DESCRIPTION
- Adds missing geometry_msgs to `ihmc_ros_common`.
- Tweak the installation rules in `ihmc_ros_java_adapter` to make the ROS buildfarm happy. 
