### PR TITLE
Include geometry_msgs as a build dependency

### DIFF
--- a/ihmc_msgs/package.xml
+++ b/ihmc_msgs/package.xml
@@ -16,6 +16,8 @@
   <build_depend>geometry_msgs</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>geometry_msgs</run_depend>
+
   <run_depend>geometry_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>std_msgs</run_depend>


### PR DESCRIPTION
Need to include geometry_msgs in build time. The [ROS buildfarm is failing without it](http://build.ros.org/view/Ibin_uT64/job/Ibin_uT64__ihmc_msgs__ubuntu_trusty_amd64__binary/8/console).

